### PR TITLE
Reference to arm config file in /etc/arm

### DIFF
--- a/arm/config/config.py
+++ b/arm/config/config.py
@@ -4,7 +4,7 @@ import os
 # import re
 import yaml
 
-yamlfile = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../..", "arm.yaml")
+yamlfile = os.path.join(os.path.dirname(os.path.abspath(__file__)), "/etc/arm", "arm.yaml")
 
 with open(yamlfile, "r") as f:
     cfg = yaml.load(f)


### PR DESCRIPTION
Strange config file location in /opt/arm, and a symlinked file in /etc/arm. 
This commit uses the /etc/arm/arm.yaml as the config file. This is in line with the standard config file location.